### PR TITLE
Add support for skipupdate attribute in entity schema #13

### DIFF
--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/Configurations/AllEntities_SomePluginsDisabled_MixedIdentifiers_data_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/Configurations/AllEntities_SomePluginsDisabled_MixedIdentifiers_data_schema.xml
@@ -1,17 +1,17 @@
 <entities >
-  <entity name="incident" displayname="Case" etc="112" primaryidfield="incidentid" primarynamefield="title" disableplugins="true">
+  <entity name="incident" displayname="Case" etc="112" primaryidfield="incidentid" primarynamefield="title" disableplugins="true" skipupdate="false">
     <fields>
       <field displayname="Customer" name="customerid" type="entityreference" lookupType="account|contact" />
       <field updateCompare="true" displayname="Case" name="incidentid" type="guid" primaryKey="true" />
     </fields>
   </entity>
-  <entity name="invoice" displayname="Invoice" etc="1090" primaryidfield="invoiceid" primarynamefield="name" disableplugins="false">
+  <entity name="invoice" displayname="Invoice" etc="1090" primaryidfield="invoiceid" primarynamefield="name" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Invoice" name="invoiceid" type="guid" primaryKey="true" />
       <field displayname="Total Tax" name="totaltax" type="money" />
     </fields>
   </entity>
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="true">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="true" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Article Public Number" name="articlepublicnumber" type="string" />
       <field displayname="Short Description" name="description" type="string" />
@@ -27,25 +27,25 @@
       <field displayname="Status Reason" name="statuscode" type="status" />
     </fields>
   </entity>
-  <entity name="msdyn_approval" displayname="Approval" etc="10032" primaryidfield="activityid" primarynamefield="subject" disableplugins="false">
+  <entity name="msdyn_approval" displayname="Approval" etc="10032" primaryidfield="activityid" primarynamefield="subject" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Activity" name="activityid" type="guid" primaryKey="true" />
       <field displayname="Customers" name="customers" type="partylist" />
     </fields>
   </entity>
-  <entity name="msdyn_purchaseorderproduct" displayname="Purchase Order Product" etc="10149" primaryidfield="msdyn_purchaseorderproductid" primarynamefield="msdyn_name" disableplugins="false">
+  <entity name="msdyn_purchaseorderproduct" displayname="Purchase Order Product" etc="10149" primaryidfield="msdyn_purchaseorderproductid" primarynamefield="msdyn_name" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Purchase Order Product" name="msdyn_purchaseorderproductid" type="guid" primaryKey="true" />
       <field displayname="Quantity" name="msdyn_quantity" type="float" customfield="true" />
     </fields>
   </entity>
-  <entity name="msdyn_resourcerequirementdetail" displayname="Resource Requirement Detail" etc="10022" primaryidfield="msdyn_resourcerequirementdetailid" primarynamefield="msdyn_name" disableplugins="false">
+  <entity name="msdyn_resourcerequirementdetail" displayname="Resource Requirement Detail" etc="10022" primaryidfield="msdyn_resourcerequirementdetailid" primarynamefield="msdyn_name" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Hours" name="msdyn_hours" type="decimal" customfield="true" />
       <field updateCompare="true" displayname="Resource Requirement Detail" name="msdyn_resourcerequirementdetailid" type="guid" primaryKey="true" />
     </fields>
   </entity>
-  <entity name="theme" displayname="Theme" etc="2015" primaryidfield="themeid" primarynamefield="name" disableplugins="false">
+  <entity name="theme" displayname="Theme" etc="2015" primaryidfield="themeid" primarynamefield="name" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Default Theme" name="isdefaulttheme" type="bool" />
       <field updateCompare="true" displayname="Theme" name="themeid" type="guid" primaryKey="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/Configurations/MultiValueIdentifierSchema_data_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/Configurations/MultiValueIdentifierSchema_data_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="contact" displayname="Contact" etc="2" primaryidfield="contactid" primarynamefield="fullname" disableplugins="false">
+  <entity name="contact" displayname="Contact" etc="2" primaryidfield="contactid" primarynamefield="fullname" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Birthday" name="birthdate" type="datetime" />
       <field displayname="Contact" name="contactid" type="guid" primaryKey="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/Configurations/MultipleSourcesOfMetadata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/Configurations/MultipleSourcesOfMetadata_schema.xml
@@ -1,23 +1,23 @@
 ﻿<entities>
-  <entity name="account" displayname="Account" etc="1" primaryidfield="accountid" disableplugins="false">
+  <entity name="account" displayname="Account" etc="1" primaryidfield="accountid" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Account" name="accountid" type="guid" primaryKey="true" />
       <field displayname="Created By" name="createdby" type="entityreference" lookupType="contact" />
     </fields>
   </entity>
-  <entity name="incident" displayname="Case" etc="112" primaryidfield="incidentid" primarynamefield="title" disableplugins="false">
+  <entity name="incident" displayname="Case" etc="112" primaryidfield="incidentid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Customer" name="customerid" type="entityreference" lookupType="account|contact" />
       <field updateCompare="true" displayname="Case" name="incidentid" type="guid" primaryKey="true" />
     </fields>
   </entity>
-  <entity name="invoice" displayname="Invoice" etc="1090" primaryidfield="invoiceid" primarynamefield="name" disableplugins="false">
+  <entity name="invoice" displayname="Invoice" etc="1090" primaryidfield="invoiceid" primarynamefield="name" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Invoice" name="invoiceid" type="guid" primaryKey="true" />
       <field displayname="Total Tax" name="totaltax" type="money" />
     </fields>
   </entity>
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Short Description" name="description" type="string" />
       <field displayname="Expiration State Id" name="expirationstateid" type="number" />
@@ -32,30 +32,30 @@
       <field displayname="Status Reason" name="statuscode" type="status" />
     </fields>
   </entity>
-  <entity name="msdyn_approval" displayname="Approval" etc="10032" primaryidfield="activityid" primarynamefield="subject" disableplugins="false">
+  <entity name="msdyn_approval" displayname="Approval" etc="10032" primaryidfield="activityid" primarynamefield="subject" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Activity" name="activityid" type="guid" primaryKey="true" />
       <field displayname="Customers" name="customers" type="partylist" />
     </fields>
   </entity>
-  <entity name="msdyn_purchaseorderproduct" displayname="Purchase Order Product" etc="10149" primaryidfield="msdyn_purchaseorderproductid" primarynamefield="msdyn_name" disableplugins="false">
+  <entity name="msdyn_purchaseorderproduct" displayname="Purchase Order Product" etc="10149" primaryidfield="msdyn_purchaseorderproductid" primarynamefield="msdyn_name" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Purchase Order Product" name="msdyn_purchaseorderproductid" type="guid" primaryKey="true" />
       <field displayname="Quantity" name="msdyn_quantity" type="float" customfield="true" />
     </fields>
   </entity>
-  <entity name="msdyn_resourcerequirementdetail" displayname="Resource Requirement Detail" etc="10022" primaryidfield="msdyn_resourcerequirementdetailid" primarynamefield="msdyn_name" disableplugins="false">
+  <entity name="msdyn_resourcerequirementdetail" displayname="Resource Requirement Detail" etc="10022" primaryidfield="msdyn_resourcerequirementdetailid" primarynamefield="msdyn_name" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Hours" name="msdyn_hours" type="decimal" customfield="true" />
       <field updateCompare="true" displayname="Resource Requirement Detail" name="msdyn_resourcerequirementdetailid" type="guid" primaryKey="true" />
     </fields>
   </entity>
-  <entity name="role" displayname="Security Role" etc="1036" primaryidfield="roleid" disableplugins="false">
+  <entity name="role" displayname="Security Role" etc="1036" primaryidfield="roleid" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Role" name="roleid" type="guid" primaryKey="true" />
     </fields>
   </entity>
-  <entity name="systemuser" displayname="User" etc="8" primaryidfield="systemuserid" disableplugins="false">
+  <entity name="systemuser" displayname="User" etc="8" primaryidfield="systemuserid" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="First Name" name="firstname" type="string" />
       <field displayname="Last Name" name="lastname" type="string" />
@@ -65,7 +65,7 @@
       <relationship name="systemuserroles" manyToMany="true" isreflexive="false" relatedEntityName="systemuserroles" m2mTargetEntity="role" m2mTargetEntityPrimaryKey="roleid" />
     </relationships>
   </entity>
-  <entity name="theme" displayname="Theme" etc="2015" primaryidfield="themeid" primarynamefield="name" disableplugins="false">
+  <entity name="theme" displayname="Theme" etc="2015" primaryidfield="themeid" primarynamefield="name" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Default Theme" name="isdefaulttheme" type="bool" />
       <field updateCompare="true" displayname="Theme" name="themeid" type="guid" primaryKey="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/Configurations/SingleEntity_AllPluginsDisabled_data_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/Configurations/SingleEntity_AllPluginsDisabled_data_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="account" displayname="Account" etc="1" primaryidfield="accountid" primarynamefield="name" disableplugins="true">
+  <entity name="account" displayname="Account" etc="1" primaryidfield="accountid" primarynamefield="name" disableplugins="true" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Account" name="accountid" type="guid" primaryKey="true" />
       <field displayname="Account Name" name="name" type="string" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/Configurations/SingleIdentifierSchema_data_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/Configurations/SingleIdentifierSchema_data_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="contact" displayname="Contact" etc="2" primaryidfield="contactid" primarynamefield="fullname" disableplugins="false">
+  <entity name="contact" displayname="Contact" etc="2" primaryidfield="contactid" primarynamefield="fullname" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Contact" name="contactid" type="guid" primaryKey="true" />
       <field updateCompare="true" displayname="Email" name="emailaddress1" type="string" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/BooleanTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/BooleanTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="theme" displayname="Theme" etc="2015" primaryidfield="themeid" primarynamefield="name" disableplugins="false">
+  <entity name="theme" displayname="Theme" etc="2015" primaryidfield="themeid" primarynamefield="name" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Default Theme" name="isdefaulttheme" type="bool" />
       <field updateCompare="true" displayname="Theme" name="themeid" type="guid" primaryKey="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/CustomerTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/CustomerTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="incident" displayname="Case" etc="112" primaryidfield="incidentid" primarynamefield="title" disableplugins="false">
+  <entity name="incident" displayname="Case" etc="112" primaryidfield="incidentid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Customer" name="customerid" type="entityreference" lookupType="account|contact" />
       <field updateCompare="true" displayname="Case" name="incidentid" type="guid" primaryKey="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/DateTimeTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/DateTimeTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Knowledge Article" name="knowledgearticleid" type="guid" primaryKey="true" />
       <field displayname="Publish On" name="publishon" type="datetime" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/DecimalTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/DecimalTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="msdyn_resourcerequirementdetail" displayname="Resource Requirement Detail" etc="10022" primaryidfield="msdyn_resourcerequirementdetailid" primarynamefield="msdyn_name" disableplugins="false">
+  <entity name="msdyn_resourcerequirementdetail" displayname="Resource Requirement Detail" etc="10022" primaryidfield="msdyn_resourcerequirementdetailid" primarynamefield="msdyn_name" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Hours" name="msdyn_hours" type="decimal" customfield="true" />
       <field updateCompare="true" displayname="Resource Requirement Detail" name="msdyn_resourcerequirementdetailid" type="guid" primaryKey="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/DoubleTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/DoubleTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="msdyn_purchaseorderproduct" displayname="Purchase Order Product" etc="10149" primaryidfield="msdyn_purchaseorderproductid" primarynamefield="msdyn_name" disableplugins="false">
+  <entity name="msdyn_purchaseorderproduct" displayname="Purchase Order Product" etc="10149" primaryidfield="msdyn_purchaseorderproductid" primarynamefield="msdyn_name" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Purchase Order Product" name="msdyn_purchaseorderproductid" type="guid" primaryKey="true" />
       <field displayname="Quantity" name="msdyn_quantity" type="float" customfield="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/IntegerTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/IntegerTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Expiration State Id" name="expirationstateid" type="number" />
       <field updateCompare="true" displayname="Knowledge Article" name="knowledgearticleid" type="guid" primaryKey="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/LookupTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/LookupTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Knowledge Article" name="knowledgearticleid" type="guid" primaryKey="true" />
       <field displayname="Previous Article Content ID" name="previousarticlecontentid" type="entityreference" lookupType="knowledgearticle" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/MemoTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/MemoTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Keywords" name="keywords" type="string" />
       <field updateCompare="true" displayname="Knowledge Article" name="knowledgearticleid" type="guid" primaryKey="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/MoneyTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/MoneyTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="invoice" displayname="Invoice" etc="1090" primaryidfield="invoiceid" primarynamefield="name" disableplugins="false">
+  <entity name="invoice" displayname="Invoice" etc="1090" primaryidfield="invoiceid" primarynamefield="name" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Invoice" name="invoiceid" type="guid" primaryKey="true" />
       <field displayname="Total Tax" name="totaltax" type="money" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/OwnerTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/OwnerTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Knowledge Article" name="knowledgearticleid" type="guid" primaryKey="true" />
       <field displayname="Owner" name="ownerid" type="owner" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/PartyListTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/PartyListTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="msdyn_approval" displayname="Approval" etc="10032" primaryidfield="activityid" primarynamefield="subject" disableplugins="false">
+  <entity name="msdyn_approval" displayname="Approval" etc="10032" primaryidfield="activityid" primarynamefield="subject" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Approval" name="activityid" type="guid" primaryKey="true" />
       <field displayname="Customers" name="customers" type="partylist" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/PicklistTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/PicklistTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Expired Review Options" name="expiredreviewoptions" type="optionsetvalue" />
       <field updateCompare="true" displayname="Knowledge Article" name="knowledgearticleid" type="guid" primaryKey="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/StateTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/StateTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Knowledge Article" name="knowledgearticleid" type="guid" primaryKey="true" />
       <field displayname="Status" name="statecode" type="state" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/StatusTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/StatusTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Knowledge Article" name="knowledgearticleid" type="guid" primaryKey="true" />
       <field displayname="Status Reason" name="statuscode" type="status" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/StringTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/StringTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field displayname="Short Description" name="description" type="string" />
       <field updateCompare="true" displayname="Knowledge Article" name="knowledgearticleid" type="guid" primaryKey="true" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/UniqueIdentifierTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/UniqueIdentifierTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false">
+  <entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Knowledge Article" name="knowledgearticleid" type="guid" primaryKey="true" />
       <field displayname="Stage Id" name="stageid" type="guid" />

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/m2mReflexiveRelationshipTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/m2mReflexiveRelationshipTypedata_schema.xml
@@ -1,5 +1,5 @@
 <entities >
-  <entity name="msdyusd_agentscriptaction" displayname="Action Call" etc="10335" primaryidfield="msdyusd_agentscriptactionid" primarynamefield="msdyusd_name" disableplugins="false">
+  <entity name="msdyusd_agentscriptaction" displayname="Action Call" etc="10335" primaryidfield="msdyusd_agentscriptactionid" primarynamefield="msdyusd_name" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Agent Script Action" name="msdyusd_agentscriptactionid" type="guid" primaryKey="true" />
     </fields>

--- a/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/m2mRelationshipTypedata_schema.xml
+++ b/Microsoft.Xrm.DevOps.Data.Tests/lib/PrimitiveTypes/m2mRelationshipTypedata_schema.xml
@@ -1,10 +1,10 @@
 <entities >
-  <entity name="role" displayname="Security Role" etc="1036" primaryidfield="roleid" primarynamefield="name" disableplugins="false">
+  <entity name="role" displayname="Security Role" etc="1036" primaryidfield="roleid" primarynamefield="name" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="Role" name="roleid" type="guid" primaryKey="true" />
     </fields>
   </entity>
-  <entity name="systemuser" displayname="User" etc="8" primaryidfield="systemuserid" primarynamefield="fullname" disableplugins="false">
+  <entity name="systemuser" displayname="User" etc="8" primaryidfield="systemuserid" primarynamefield="fullname" disableplugins="false" skipupdate="false">
     <fields>
       <field updateCompare="true" displayname="User" name="systemuserid" type="guid" primaryKey="true" />
     </fields>

--- a/Microsoft.Xrm.DevOps.Data/Builders/DataBuilder.cs
+++ b/Microsoft.Xrm.DevOps.Data/Builders/DataBuilder.cs
@@ -376,9 +376,11 @@ namespace Microsoft.Xrm.DevOps.Data
                 this._Entities[logicalName].FetchedAllMetadata = true;
             }
         }
-
+   
         private void AddMetadataFromSchema(SchemaXml.Entity schemaXML)
         {
+            this._Entities[schemaXML.Name].PluginsDisabled = schemaXML.Disableplugins == "true";
+            this._Entities[schemaXML.Name].SkipUpdate = schemaXML.Skipupdate == "true";
             this._Entities[schemaXML.Name].Metadata = Builders.XmlImporter.GenerateAdditionalMetadata(this._Entities[schemaXML.Name].Metadata, schemaXML);
         }
 

--- a/Microsoft.Xrm.DevOps.Data/Builders/XmlSchemaBuilder.cs
+++ b/Microsoft.Xrm.DevOps.Data/Builders/XmlSchemaBuilder.cs
@@ -70,6 +70,8 @@ namespace Microsoft.Xrm.DevOps.Data
                 Primarynamefield = builderEntityMetadata.Metadata.PrimaryNameAttribute,
                 Disableplugins = (builderEntityMetadata.PluginsDisabled == null
                                    || builderEntityMetadata.PluginsDisabled == false ? "false" : "true"),
+                Skipupdate = (builderEntityMetadata.SkipUpdate == null
+                                    || builderEntityMetadata.SkipUpdate == false ? "false" : "true"),
                 Fields = new SchemaXml.Fields()
                 {
                     Field = new List<SchemaXml.Field>()

--- a/Microsoft.Xrm.DevOps.Data/SupportClasses/BuilderEntityMetadata.cs
+++ b/Microsoft.Xrm.DevOps.Data/SupportClasses/BuilderEntityMetadata.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Xrm.DevOps.Data
         public List<String> Attributes { get; private set; }
         public List<String> Identifiers = new List<String>();
         public Boolean? PluginsDisabled = null;
+        public Boolean? SkipUpdate = null;
         public Queue<Entity> Entities { get; set; }
         public Dictionary<String, Dictionary<Guid, List<Guid>>> RelatedEntities = new Dictionary<String, Dictionary<Guid, List<Guid>>>();
 

--- a/Microsoft.Xrm.DevOps.Data/SupportClasses/SchemaXmlTemplate.cs
+++ b/Microsoft.Xrm.DevOps.Data/SupportClasses/SchemaXmlTemplate.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Xrm.DevOps.Data.SchemaXml
         public string Primarynamefield { get; set; }
         [XmlAttribute(AttributeName = "disableplugins")]
         public string Disableplugins { get; set; }
+        [XmlAttribute(AttributeName = "skipupdate")]
+        public string Skipupdate {get; set;}
         [XmlElement(ElementName = "fields")]
         public Fields Fields { get; set; }
         [XmlElement(ElementName = "relationships")]


### PR DESCRIPTION
Synopsis :Changed entity schema to support new skipupdate attribute on the entity which appeared in a recent update to the Data Migration Utility.

<entity name="knowledgearticle" displayname="Knowledge Article" etc="9953" primaryidfield="knowledgearticleid" primarynamefield="title" disableplugins="false" skipupdate="false">

Updated SchemaXmlTemplate with new attribute for skipupdate. 
Updated BuilderEntityData to with new property for Skipupdate. 
Updated SchemaBuilder to set Skipupdate. 
Updated DataBuilder to set Skipupdate when appending data packages. 
Fixed bug in DataBuilder that ignored existing Disableplugin settings when appending data packages. Updated expected test results to reflect new schema attribute. 