### PR TITLE
Bugfix: Test runner in x64 mode errors our due to namespace ordering …

### DIFF
--- a/Microsoft.Xrm.DevOps.Data.Tests/.runsettings
+++ b/Microsoft.Xrm.DevOps.Data.Tests/.runsettings
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- For more information, see https://docs.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file  -->
+<RunSettings>
+  <!-- Configurations that affect the Test Framework -->
+  <RunConfiguration>
+    <!-- Quick and dirty workaround because of inconsistent XML namespace serialization order between x86 and x64 test runs: https://github.com/abvogel/Microsoft.Xrm.DevOps.Data/issues/21 -->
+    <TargetPlatform>x86</TargetPlatform>
+  </RunConfiguration>
+</RunSettings>

--- a/Microsoft.Xrm.DevOps.Data.Tests/Microsoft.Xrm.DevOps.Data.Tests.csproj
+++ b/Microsoft.Xrm.DevOps.Data.Tests/Microsoft.Xrm.DevOps.Data.Tests.csproj
@@ -21,6 +21,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\.runsettings</RunSettingsFilePath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -170,6 +171,9 @@
     <None Include="app.config" />
     <None Include="lib\Metadata\CrmSchema.dat" />
     <None Include="packages.config" />
+    <None Include=".runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Xrm.DevOps.Data\Microsoft.Xrm.DevOps.Data.csproj">


### PR DESCRIPTION
…on XML serialzation: https://github.com/abvogel/Microsoft.Xrm.DevOps.Data/issues/21