### PR TITLE
Export-CdmDataPackage - supports saving .xml files within directory not as a zip file.

### DIFF
--- a/Microsoft.Xrm.DevOps.Data.PowerShell/Cmdlets/Export-CrmDataPackage.cs
+++ b/Microsoft.Xrm.DevOps.Data.PowerShell/Cmdlets/Export-CrmDataPackage.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Management.Automation;
 using Microsoft.Xrm.Sdk;
 using Ionic.Zip;
+using System.Xml;
+using System.Text;
 
 namespace Microsoft.Xrm.DevOps.Data.PowerShell.Cmdlets
 {
@@ -93,18 +95,25 @@ namespace Microsoft.Xrm.DevOps.Data.PowerShell.Cmdlets
             Directory.CreateDirectory(DirectoryPath);
             if (ConfirmOverwrite(contentTypesPath) && ShouldProcess(contentTypesPath, "Save"))
             {
-                GenerateVerboseMessage($"1/3 Saving {contentTypesPath}");
-                Package.ContentTypes.Save(contentTypesPath);
+                SaveXmlDocument(Package.ContentTypes, contentTypesPath);
             }
             if (ConfirmOverwrite(dataPath) && ShouldProcess(dataPath, "Save"))
             {
-                GenerateVerboseMessage($"2/3 Saving {dataPath}");
-                Package.Data.Save(dataPath);
+                SaveXmlDocument(Package.Data, dataPath);
             }
             if (ConfirmOverwrite(schemaPath) && ShouldProcess(schemaPath, "Save"))
             {
-                GenerateVerboseMessage($"3/3 Saving {schemaPath}");
-                Package.Schema.Save(schemaPath);
+                
+                SaveXmlDocument(Package.Schema, schemaPath);
+            }
+        }
+
+        private void SaveXmlDocument(XmlDocument document, string output)
+        {
+            GenerateVerboseMessage($"Saving {output}");
+            using (var sw = new StreamWriter(output, append: false, encoding: Encoding.UTF8))
+            {
+                document.Save(sw);
             }
         }
 

--- a/Microsoft.Xrm.DevOps.Data.PowerShell/Cmdlets/Export-CrmDataPackage.cs
+++ b/Microsoft.Xrm.DevOps.Data.PowerShell/Cmdlets/Export-CrmDataPackage.cs
@@ -6,50 +6,117 @@ using Ionic.Zip;
 
 namespace Microsoft.Xrm.DevOps.Data.PowerShell.Cmdlets
 {
-    [Cmdlet(VerbsData.Export, "CrmDataPackage")]
+    [Cmdlet(VerbsData.Export, "CrmDataPackage", DefaultParameterSetName = "SaveAsZip", SupportsShouldProcess = true)]
     [OutputType(typeof(PowerShell.CrmDataPackage))]
     public class ExportCrmDataPackage : PSCmdlet
     {
         [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true)]
         public CrmDataPackage Package { get; set; }
 
-        [Parameter(Position = 1)]
+        [Parameter(Position = 1, ParameterSetName = "SaveAsZip")]
         public String ZipPath { private get; set; }
+
+        /// <summary>
+        /// Saves data.xml, data_schema.xml and [Content_Types].xml within specified folder. If files exist, use Force to overwrite.
+        /// </summary>
+        [Parameter(Position = 1, ParameterSetName = "SaveInDirectory")]
+        public String DirectoryPath { private get; set; }
+
+        /// <summary>
+        /// Overwrites existing data.xml, data_schema.xml and [Content_Types].xml files in target directory
+        /// </summary>
+        [Parameter(ParameterSetName = "SaveInDirectory")]
+        public SwitchParameter Force { get; set; }
+
+        bool OverwriteYesToAll = false;
+        bool OverwriteNoToAll = false;
 
         protected override void ProcessRecord()
         {
             try
             {
-                using (ZipFile zip = new ZipFile())
+                if (!string.IsNullOrEmpty(ZipPath))
                 {
-                    GenerateVerboseMessage("Streaming [Content_Types].xml to memory.");
-                    MemoryStream contentTypeFS = new MemoryStream();
-                    Package.ContentTypes.Save(contentTypeFS);
-                    contentTypeFS.Seek(0, SeekOrigin.Begin);
-
-                    GenerateVerboseMessage("Streaming data.xml to memory.");
-                    MemoryStream dataFS = new MemoryStream();
-                    Package.Data.Save(dataFS);
-                    dataFS.Seek(0, SeekOrigin.Begin);
-
-                    GenerateVerboseMessage("Streaming data_schema.xml to memory.");
-                    MemoryStream schemaFS = new MemoryStream();
-                    Package.Schema.Save(schemaFS);
-                    schemaFS.Seek(0, SeekOrigin.Begin);
-
-                    GenerateVerboseMessage("Crossing the streams.");
-                    zip.AddEntry("[Content_Types].xml", contentTypeFS);
-                    zip.AddEntry("data.xml", dataFS);
-                    zip.AddEntry("data_schema.xml", schemaFS);
-
-                    GenerateVerboseMessage(String.Format("Zipping streams to {0}.", ZipPath));
-                    zip.Save(ZipPath);
+                    SaveAsZip();
+                }
+                if (!string.IsNullOrEmpty(DirectoryPath))
+                {
+                    SaveInDirectory();
                 }
             }
             catch (Exception ex)
             {
                 throw new Exception(ex.Message);
             }
+        }
+
+        private void SaveAsZip()
+        {
+            //Why no force there? To maintain compatbility - originally there was no Force parameter and default behavior was: zip overwrites
+            using (ZipFile zip = new ZipFile())
+            {
+                GenerateVerboseMessage("Streaming [Content_Types].xml to memory.");
+                MemoryStream contentTypeFS = new MemoryStream();
+                Package.ContentTypes.Save(contentTypeFS);
+                contentTypeFS.Seek(0, SeekOrigin.Begin);
+
+                GenerateVerboseMessage("Streaming data.xml to memory.");
+                MemoryStream dataFS = new MemoryStream();
+                Package.Data.Save(dataFS);
+                dataFS.Seek(0, SeekOrigin.Begin);
+
+                GenerateVerboseMessage("Streaming data_schema.xml to memory.");
+                MemoryStream schemaFS = new MemoryStream();
+                Package.Schema.Save(schemaFS);
+                schemaFS.Seek(0, SeekOrigin.Begin);
+
+                GenerateVerboseMessage("Crossing the streams.");
+                zip.AddEntry("[Content_Types].xml", contentTypeFS);
+                zip.AddEntry("data.xml", dataFS);
+                zip.AddEntry("data_schema.xml", schemaFS);
+
+                GenerateVerboseMessage(String.Format("Zipping streams to {0}.", ZipPath));
+
+                if (ShouldProcess(ZipPath, "Save"))
+                {
+                    zip.Save(ZipPath);
+                }
+            }
+        }
+
+        private void SaveInDirectory()
+        {
+            OverwriteYesToAll = Force;
+            string contentTypesPath = Path.Combine(DirectoryPath, "[Content_Types].xml");
+            string dataPath = Path.Combine(DirectoryPath, "data.xml");
+            string schemaPath = Path.Combine(DirectoryPath, "data_schema.xml");
+            Directory.CreateDirectory(DirectoryPath);
+            if (ConfirmOverwrite(contentTypesPath) && ShouldProcess(contentTypesPath, "Save"))
+            {
+                GenerateVerboseMessage($"1/3 Saving {contentTypesPath}");
+                Package.ContentTypes.Save(contentTypesPath);
+            }
+            if (ConfirmOverwrite(dataPath) && ShouldProcess(dataPath, "Save"))
+            {
+                GenerateVerboseMessage($"2/3 Saving {dataPath}");
+                Package.Data.Save(dataPath);
+            }
+            if (ConfirmOverwrite(schemaPath) && ShouldProcess(schemaPath, "Save"))
+            {
+                GenerateVerboseMessage($"3/3 Saving {schemaPath}");
+                Package.Schema.Save(schemaPath);
+            }
+        }
+
+        private bool ConfirmOverwrite(string path)
+        {
+            if (OverwriteNoToAll) { return false; }
+            if (OverwriteYesToAll) { return true; }
+            if (File.Exists(path))
+            {
+                return ShouldContinue($"File at path '{path}' already exists. Use {nameof(Force)} parameter to overwrite", "Overwrite", ref OverwriteYesToAll, ref OverwriteNoToAll);
+            }
+            return true;
         }
 
         private void GenerateVerboseMessage(string v)


### PR DESCRIPTION
This enables exporting data from env and directly saving .xml files in a folder which is source-control friendly and diffs can be applied.

```powershell
Get-CrmDataPackage -Conn $crm -Fetches '<fetch version="1.0" output-format="xml-platform" mapping="logical" distinct="false"><entity name="account"><attribute name="name" /><attribute name="accountid" /><attribute name="new_isinternalaccount" /><attribute name="new_clientid" /><order attribute="name" descending="false" /><filter type="and"><condition attribute="new_isinternalaccount" operator="eq" value="1" /></filter></entity></fetch>' `
    | Export-CrmDataPackage -DirectoryPath "some\path\accounts"
```

Additionally add support -WhatIf parameter for Export command.

The command compatibility is left as is - the default is for saving zip files and overwriting stuff.